### PR TITLE
Enable CORS

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "a HTTP REST client server game. yeah, that does not sound like fun.",
   "main": "server.js",
   "dependencies": {
+    "body-parser": "^1.9.2",
+    "cors": "^2.5.3",
     "express.io": "~1.1.13",
-    "request": "^2.48.0",
-    "body-parser": "^1.9.2"
+    "request": "^2.48.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -6,12 +6,14 @@ var Express    = require('express.io');
 var BodyParser = require('body-parser');
 var Game       = require('./lib/game');
 var both       = require('./lib/both');
+var cors       = require('cors');
 
 var State = Game.state();
 var App = new Express();
 
 App.use(BodyParser.urlencoded({ extended: true }));
 App.use(Express.static(__dirname + '/static'));
+App.use(cors());
 App.http().io();
 
 App.post('/register/', function (req, res) { Game.register(State, req, res, App.io); });


### PR DESCRIPTION
If someone wants to build a client which runs in a browser (who would be
so crazy?!), the server must explicitly allow cross-origin sharing. The
node "cors" module is a simple way to enable this.
