### PR TITLE
Change distance calculation to rectangular distance metric

### DIFF
--- a/lib/maps.js
+++ b/lib/maps.js
@@ -208,9 +208,9 @@ function isValidTreasureTile (tile, pos, castle1, castle2) {
 }
 
 function dist (posA, posB) {
-	var a = posA.x - posB.x;
-	var b = posA.y - posB.y;
-	return Math.sqrt(a * a + b * b);
+	var a = Math.abs(posA.x - posB.x);
+	var b = Math.abs(posA.y - posB.y);
+	return Math.max(a,b);
 }
 
 module.exports = {


### PR DESCRIPTION
Otherwise treasures could be placed in corners of initial 7x7 (mountain) views,
because e.g. sqrt(3*3+3*3) >= MIN_DIST (which is 4)
